### PR TITLE
add callback to error on no host match

### DIFF
--- a/callback_plugins/no_hosts_matched.py
+++ b/callback_plugins/no_hosts_matched.py
@@ -1,0 +1,33 @@
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+import time
+import sys
+
+from ansible.plugins.callback import CallbackBase
+
+
+class CallbackModule(CallbackBase):
+    """
+    This callback module exits non-zero if no hosts match
+    """
+    CALLBACK_VERSION = 2.0
+    CALLBACK_TYPE = 'aggregate'
+    CALLBACK_NAME = 'no_hosts_match_exit_non_zero'
+    CALLBACK_NEEDS_WHITELIST = False
+
+    def __init__(self):
+        super(CallbackModule, self).__init__()
+
+    def playbook_on_stats(self, stats):
+        found_stats = False
+
+        for key in ['ok', 'failures', 'dark', 'changed', 'skipped']:
+            if len(getattr(stats, key)) > 0:
+                found_stats = True
+                break
+
+        if found_stats == False:
+            sys.exit(10)

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,11 @@ class Enveigle extends Command {
       description: 'local environment name',
       default: 'development',
     }),
+    cbpath: flags.string({
+      char: 'c',
+      description: 'callback path',
+      default: 'lib/trellis/plugins/callback',
+    }),
   }
 
   async run() {
@@ -23,30 +28,40 @@ class Enveigle extends Command {
 
     const tasks = new Listr([
       {
-        title: 'Copy enveigle.yml',
+        title: 'Copy enveigle.yml & callback',
         task: () => {
-          const source = path.join(__dirname, '../templates/enveigle.yml')
-          fs.copyFileSync(source, 'enveigle.yml')
+          const enveigle = path.join(__dirname, '../templates/enveigle.yml')
+          const callback = path.join(__dirname, '../callback_plugins/no_hosts_matched.py')
+          fs.copyFileSync(callback, (flags.cbpath + '/no_hosts_matcheded.py'))
+          fs.copyFileSync(enveigle, 'enveigle.yml')
         }
       },
       {
         title: 'Template .env files to local system',
-        task: (_, task) => {
-          task.output = `$ ansible-playbook enveigle.yml -e env=${flags.env}`
-          return execa('ansible-playbook', ['enveigle.yml', `-e env=${flags.env}`])
-        }
+        task: (_, task) =>  execa('ansible-playbook', ['enveigle.yml', `-e env=${flags.env}`])
+        .catch((result) => {
+          if (result.code = 10) {
+            throw new Error('Could not match supplied host pattern')
+          } else {
+            task.skip('Something went wrong. Try again!')
+          }
+        })
       },
       {
         title: 'Remove enveigle.yml',
-        task: () => fs.unlinkSync('enveigle.yml')
+        task: () => {
+          fs.unlinkSync('enveigle.yml')
+          fs.unlinkSync(flags.cbpath + '/no_hosts_matcheded.py')
+        }
       },
     ])
 
     tasks.run().catch(err => {
-      console.error(err)
       console.error('##########################################')
       console.error('Abort! Something went wrong')
       console.error('You have to delete enveigle.yml manually')
+      console.error('Error message:')
+      console.error(err)
     })
   }
 }


### PR DESCRIPTION
Adds the callback plugin found [here](https://gist.github.com/jjshoe/ace3070906e5bc5cc432) and copies it to the default Trellis callback plugin directory. Also adds a flag for providing a different callback plugin directory. 

I don't see an easy way to check the error so it's not displayed twice or format it to look better, but maybe there's a way?